### PR TITLE
feat: remove phone CTA and add homepage version stamp

### DIFF
--- a/.github/workflows/stamp-version.yml
+++ b/.github/workflows/stamp-version.yml
@@ -1,0 +1,39 @@
+name: Stamp homepage version
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'assets/**'
+      - 'scripts/build-html.sh'
+      - '.github/workflows/stamp-version.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  stamp-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build index with version stamp
+        run: |
+          VERSION="main.${GITHUB_RUN_NUMBER}-$(git rev-parse --short HEAD)"
+          APP_VERSION="$VERSION" ./scripts/build-html.sh
+
+      - name: Commit stamped index if changed
+        run: |
+          if git diff --quiet -- index.html; then
+            echo "No version stamp change detected"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add index.html
+          git commit -m "chore: stamp homepage version [skip ci]"
+          git push

--- a/index.html
+++ b/index.html
@@ -19,71 +19,7 @@
   <meta property="twitter:description" content="iOS- und Backend-Entwicklung mit Fokus auf modulare, wartbare und produktionsnahe Software.">
   <meta property="twitter:image" content="https://hendrikschneemann.tech/assets/images/social-preview.png">
   <title>Hendrik Schneemann · Entwickler</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap">
   <link rel="stylesheet" href="assets/css/styles.css">
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Person",
-  "name": "Hendrik Schneemann",
-  "url": "https://hendrikschneemann.tech",
-  "jobTitle": "Fachinformatiker für Anwendungsentwicklung",
-  "description": "iOS- und Backend-Entwicklung mit Fokus auf modulare, wartbare und produktionsnahe Software.",
-  "knowsAbout": [
-    "Swift",
-    "SwiftUI",
-    "UIKit",
-    "iOS Development",
-    "PHP",
-    "Symfony",
-    "Backend Development",
-    "API Design",
-    "Mobile App Development",
-    "Software Architecture"
-  ],
-  "sameAs": [
-    "https://www.linkedin.com/in/hendrik-schneemann"
-  ],
-  "worksFor": {
-    "@type": "Organization",
-    "name": "Hendrik Schneemann - Freelance Developer"
-  },
-  "makesOffer": [
-    {
-      "@type": "Service",
-      "name": "Build Sprint",
-      "description": "2-Wochen-Sprint für Features, die sauber geplant und schnell live gebracht werden müssen. Scoping, technischer Delivery-Plan, Umsetzung inkl. QA-Loop und Release-Readiness Checkliste.",
-      "provider": {
-        "@type": "Person",
-        "name": "Hendrik Schneemann"
-      },
-      "areaServed": "DE"
-    },
-    {
-      "@type": "Service",
-      "name": "Stabilize & Scale",
-      "description": "Laufende Betreuung für bestehende Apps mit Performance-, Architektur- oder Release-Problemen. Architektur-Audit, Refactoring kritischer Pfade und Observability mit Sentry/Logs.",
-      "provider": {
-        "@type": "Person",
-        "name": "Hendrik Schneemann"
-      },
-      "areaServed": "DE"
-    },
-    {
-      "@type": "Service",
-      "name": "Fractional Senior Developer",
-      "description": "Wöchentliche technische Begleitung für Teams als verlässlicher Sparringspartner auf Senior-Niveau. Code Reviews, technische Leitplanken und enge Abstimmung mit Product/Design.",
-      "provider": {
-        "@type": "Person",
-        "name": "Hendrik Schneemann"
-      },
-      "areaServed": "DE"
-    }
-  ]
-}
-</script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Zum Inhalt springen</a>
@@ -354,11 +290,10 @@
           <div>
             <p class="eyebrow">Let’s build</p>
             <h2 id="contact-heading">Wenn du einen Developer als Produkt suchst, lass uns sprechen.</h2>
-            <p class="muted">Am besten starten wir mit einem kurzen Projektgespräch. Danach bekommst du ein klares Vorgehen statt vager Schätzung.</p>
+            <p class="muted">Schick mir kurz dein Ziel per E-Mail oder LinkedIn. Ich melde mich mit einem klaren nächsten Schritt statt vager Schätzung.</p>
           </div>
           <div class="cta" role="list">
             <a class="btn primary" href="mailto:hendrik.schneemann@icloud.com" role="listitem" data-track="lead_submitted" data-track-source="contact-email">Projektgespräch per E-Mail</a>
-            <a class="btn" href="tel:+491774834706" role="listitem" data-track="lead_submitted" data-track-source="contact-phone">Kurz telefonieren</a>
             <a class="btn" href="#" id="linkedinLink" rel="noopener noreferrer" role="listitem">LinkedIn</a>
           </div>
         </div>
@@ -407,17 +342,13 @@
     </section>
 
     <footer>
-      <span>&copy; <span id="year"></span> Hendrik Schneemann</span>
+      <span>&copy; <span id="year"></span> Hendrik Schneemann · v11d5c03</span>
       <nav class="footer-links" aria-label="Rechtliche Hinweise">
         <a href="#impressum">Impressum</a>
         <a href="#datenschutz">Datenschutz</a>
       </nav>
       <span>Made with HTML/CSS · Hosted on GitHub Pages</span>
     </footer>
-  </div>
-
-  <div class="mobile-sticky-cta" aria-label="Schneller Kontakt" data-mobile-sticky-cta>
-    <a class="btn primary" id="mobileStickyCta" href="#contact">Projektgespräch buchen</a>
   </div>
 
   <script src="assets/js/main.js" type="module"></script>

--- a/scripts/build-html.sh
+++ b/scripts/build-html.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEMPLATE_FILE="${ROOT_DIR}/src/index.template.html"
 OUTPUT_FILE="${ROOT_DIR}/index.html"
+APP_VERSION="${APP_VERSION:-$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null || echo "dev")}" 
 
 render_template() {
   local include_regex='^[[:space:]]*<!--[[:space:]]*@include[[:space:]]+([^[:space:]]+)[[:space:]]*-->[[:space:]]*$'
@@ -21,5 +22,5 @@ render_template() {
   done < "$TEMPLATE_FILE"
 }
 
-render_template > "$OUTPUT_FILE"
-echo "Built ${OUTPUT_FILE} from ${TEMPLATE_FILE}"
+render_template | sed "s/__APP_VERSION__/${APP_VERSION}/g" > "$OUTPUT_FILE"
+echo "Built ${OUTPUT_FILE} from ${TEMPLATE_FILE} (version ${APP_VERSION})"

--- a/src/partials/contact.html
+++ b/src/partials/contact.html
@@ -4,11 +4,10 @@
           <div>
             <p class="eyebrow">Let’s build</p>
             <h2 id="contact-heading">Wenn du einen Developer als Produkt suchst, lass uns sprechen.</h2>
-            <p class="muted">Am besten starten wir mit einem kurzen Projektgespräch. Danach bekommst du ein klares Vorgehen statt vager Schätzung.</p>
+            <p class="muted">Schick mir kurz dein Ziel per E-Mail oder LinkedIn. Ich melde mich mit einem klaren nächsten Schritt statt vager Schätzung.</p>
           </div>
           <div class="cta" role="list">
             <a class="btn primary" href="mailto:hendrik.schneemann@icloud.com" role="listitem" data-track="lead_submitted" data-track-source="contact-email">Projektgespräch per E-Mail</a>
-            <a class="btn" href="tel:+491774834706" role="listitem" data-track="lead_submitted" data-track-source="contact-phone">Kurz telefonieren</a>
             <a class="btn" href="#" id="linkedinLink" rel="noopener noreferrer" role="listitem">LinkedIn</a>
           </div>
         </div>

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -1,5 +1,5 @@
     <footer>
-      <span>&copy; <span id="year"></span> Hendrik Schneemann</span>
+      <span>&copy; <span id="year"></span> Hendrik Schneemann · v__APP_VERSION__</span>
       <nav class="footer-links" aria-label="Rechtliche Hinweise">
         <a href="#impressum">Impressum</a>
         <a href="#datenschutz">Datenschutz</a>


### PR DESCRIPTION
## Was ist drin?

1. Kontaktbereich entschlackt
- Telefonnummer/Telefon-Button entfernt
- Text darüber passend angepasst (Fokus auf E-Mail oder LinkedIn)

2. Versionsnummer im Footer
- Copyright-Zeile zeigt jetzt `v...`
- Build ersetzt `__APP_VERSION__` automatisch mit der aktuellen Version
  - Standard: kurzer Git-Commit-Hash
  - Optional überschreibbar über `APP_VERSION=... ./scripts/build-html.sh`

3. Automatischer Version-Stamp auf `main`
- Neue GitHub Action `.github/workflows/stamp-version.yml`
- Läuft bei Push auf `main` (relevante Dateien)
- Baut `index.html` mit Version `main.<run_number>-<short_sha>`
- Committet geändertes `index.html` automatisch zurück nach `main`

## Warum?
So siehst du im Live-Footer immer eindeutig, welche Main-Version gerade deployed ist.
