### PR TITLE
fix: natürlicher Contact-Text + mehr Abstand zwischen Cards

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -61,24 +61,24 @@ nav a.is-active {
   background:rgba(95, 141, 255, 0.2);
 }
 
-section { margin-top:34px; }
+section { margin-top:42px; }
 
 .hero-shell {
   display:grid;
   grid-template-columns:minmax(0, 1.15fr) minmax(300px, 0.85fr);
-  gap:18px;
+  gap:22px;
   margin-top:8px;
 }
 
 .hero-side {
   display:grid;
-  gap:14px;
+  gap:18px;
 }
 
 .value-grid {
   display:grid;
   grid-template-columns:repeat(3, minmax(0, 1fr));
-  gap:14px;
+  gap:20px;
 }
 
 .section-head {
@@ -87,23 +87,23 @@ section { margin-top:34px; }
 }
 
 .offer-grid {
-  margin-top:16px;
+  margin-top:20px;
   display:grid;
   grid-template-columns:repeat(3, minmax(0, 1fr));
-  gap:14px;
+  gap:20px;
 }
 
 .showcase-grid {
   display:grid;
   grid-template-columns:repeat(3, minmax(0, 1fr));
-  gap:14px;
-  margin-top:10px;
+  gap:20px;
+  margin-top:14px;
 }
 
 .grid {
   display:grid;
   grid-template-columns:1fr 1fr;
-  gap:14px;
+  gap:20px;
 }
 
 .proof-grid {
@@ -116,7 +116,7 @@ section { margin-top:34px; }
 .conversion-pad {
   display:grid;
   grid-template-columns:1.2fr auto;
-  gap:18px;
+  gap:22px;
   align-items:end;
 }
 

--- a/index.html
+++ b/index.html
@@ -289,8 +289,8 @@
         <div class="pad conversion-pad">
           <div>
             <p class="eyebrow">Let’s build</p>
-            <h2 id="contact-heading">Wenn du einen Developer als Produkt suchst, lass uns sprechen.</h2>
-            <p class="muted">Schick mir kurz dein Ziel per E-Mail oder LinkedIn. Ich melde mich mit einem klaren nächsten Schritt statt vager Schätzung.</p>
+            <h2 id="contact-heading">Dein Produkt-MVP in Tagen statt in Wochen.</h2>
+            <p class="muted">Schick mir dein Ziel per E-Mail oder LinkedIn. Du bekommst einen konkreten Vorschlag für die nächsten Schritte statt vager Schätzungen.</p>
           </div>
           <div class="cta" role="list">
             <a class="btn primary" href="mailto:hendrik.schneemann@icloud.com" role="listitem" data-track="lead_submitted" data-track-source="contact-email">Projektgespräch per E-Mail</a>
@@ -342,7 +342,7 @@
     </section>
 
     <footer>
-      <span>&copy; <span id="year"></span> Hendrik Schneemann · v08dded5</span>
+      <span>&copy; <span id="year"></span> Hendrik Schneemann · v293ed23</span>
       <nav class="footer-links" aria-label="Rechtliche Hinweise">
         <a href="#impressum">Impressum</a>
         <a href="#datenschutz">Datenschutz</a>

--- a/src/partials/contact.html
+++ b/src/partials/contact.html
@@ -3,8 +3,8 @@
         <div class="pad conversion-pad">
           <div>
             <p class="eyebrow">Let’s build</p>
-            <h2 id="contact-heading">Wenn du einen Developer als Produkt suchst, lass uns sprechen.</h2>
-            <p class="muted">Schick mir kurz dein Ziel per E-Mail oder LinkedIn. Ich melde mich mit einem klaren nächsten Schritt statt vager Schätzung.</p>
+            <h2 id="contact-heading">Dein Produkt-MVP in Tagen statt in Wochen.</h2>
+            <p class="muted">Schick mir dein Ziel per E-Mail oder LinkedIn. Du bekommst einen konkreten Vorschlag für die nächsten Schritte statt vager Schätzungen.</p>
           </div>
           <div class="cta" role="list">
             <a class="btn primary" href="mailto:hendrik.schneemann@icloud.com" role="listitem" data-track="lead_submitted" data-track-source="contact-email">Projektgespräch per E-Mail</a>


### PR DESCRIPTION
Follow-up mit deinen zwei gewünschten Anpassungen:

1) **Contact-Copy natürlicher formuliert**
- Headline geändert zu: "Dein Produkt-MVP in Tagen statt in Wochen."
- Begleittext sprachlich entschärft und konkreter gemacht.

2) **Abstände zwischen Boxen erhöht**
- Größere Gaps in den zentralen Grids (Value, Offer, Showcase, 2-Spalten-Grid)
- Mehr vertikaler Abschnittsabstand für ruhigeren Rhythmus
- Leicht mehr Abstand in Hero- und Conversion-Layout

Hinweis: Dieser PR baut auf dem vorherigen Contact/Version-Stand auf (Telefon bereits entfernt, Version-Stamping enthalten).
