### PR TITLE
feat: mission-control dashboard page

### DIFF
--- a/assets/css/mission-control.css
+++ b/assets/css/mission-control.css
@@ -1,0 +1,291 @@
+.mission-wrap {
+  --mission-line: rgba(118, 147, 211, 0.34);
+  --mission-glow: rgba(95, 141, 255, 0.2);
+}
+
+.mission-header {
+  padding:22px;
+  border-radius:24px;
+  background:
+    radial-gradient(720px 220px at 100% -20%, rgba(126, 163, 255, 0.24), transparent 62%),
+    linear-gradient(170deg, rgba(15, 25, 44, 0.97), rgba(10, 17, 32, 0.96));
+}
+
+.mission-header-row {
+  display:flex;
+  justify-content:space-between;
+  gap:16px;
+  align-items:flex-start;
+}
+
+.mission-pill {
+  display:inline-flex;
+  align-items:center;
+  padding:8px 12px;
+  border-radius:999px;
+  border:1px solid rgba(101, 130, 187, 0.8);
+  background:rgba(18, 33, 58, 0.84);
+  color:#dbe7ff;
+  font-weight:700;
+  font-size:0.78rem;
+}
+
+.mission-tabs {
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  margin-top:18px;
+}
+
+.mission-tab {
+  border:1px solid rgba(89, 112, 153, 0.8);
+  color:#d6e2fb;
+  background:rgba(15, 29, 52, 0.84);
+  font-weight:700;
+  border-radius:12px;
+  padding:10px 14px;
+  cursor:pointer;
+  transition:transform .2s ease, border-color .2s ease, box-shadow .2s ease, background-color .2s ease;
+}
+
+.mission-tab.is-active {
+  border-color:rgba(136, 166, 227, 0.92);
+  background:rgba(77, 116, 198, 0.3);
+}
+
+.mission-grid {
+  display:grid;
+  grid-template-columns:minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  gap:18px;
+}
+
+.org-map .pad { padding-top:24px; }
+
+.panel-head {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:10px;
+  margin-bottom:14px;
+}
+
+.org-canvas {
+  position:relative;
+  display:grid;
+  gap:18px;
+  margin-top:12px;
+}
+
+.org-canvas::before {
+  content:"";
+  position:absolute;
+  inset:38px 15% auto;
+  height:1px;
+  background:linear-gradient(90deg, transparent, var(--mission-line), transparent);
+}
+
+.node-row {
+  display:grid;
+  grid-template-columns:repeat(3, minmax(0, 1fr));
+  gap:12px;
+  position:relative;
+}
+
+.node-row::before {
+  content:"";
+  position:absolute;
+  top:-12px;
+  left:50%;
+  width:1px;
+  height:12px;
+  background:var(--mission-line);
+}
+
+.node-row-small {
+  grid-template-columns:repeat(4, minmax(0, 1fr));
+}
+
+.node {
+  position:relative;
+  border:1px solid rgba(90, 114, 160, 0.84);
+  border-radius:14px;
+  padding:13px;
+  background:rgba(14, 27, 49, 0.86);
+  box-shadow:inset 0 0 0 1px rgba(173, 196, 246, 0.05), 0 0 22px rgba(95, 141, 255, 0.08);
+  transition:transform .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+
+.node::before {
+  content:"";
+  position:absolute;
+  top:-10px;
+  left:50%;
+  width:1px;
+  height:10px;
+  background:var(--mission-line);
+}
+
+.node-core {
+  justify-self:center;
+  max-width:260px;
+  width:100%;
+  text-align:center;
+  background:linear-gradient(180deg, rgba(19, 34, 62, 0.96), rgba(14, 24, 44, 0.96));
+}
+
+.node-core::before { display:none; }
+
+.node-label {
+  margin:0;
+  color:#9cb2dd;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+  font-size:0.7rem;
+  font-weight:700;
+}
+
+.node h3 {
+  margin-top:6px;
+  margin-bottom:8px;
+}
+
+.node.mini h3 {
+  font-size:0.9rem;
+  margin-bottom:0;
+}
+
+.badge {
+  display:inline-flex;
+  align-items:center;
+  border-radius:999px;
+  padding:4px 10px;
+  font-size:0.72rem;
+  font-weight:700;
+  text-transform:uppercase;
+  letter-spacing:0.05em;
+}
+
+.badge.online {
+  background:rgba(49, 198, 170, 0.18);
+  color:#7ef0d9;
+  border:1px solid rgba(69, 207, 180, 0.5);
+}
+
+.badge.busy {
+  background:rgba(244, 166, 75, 0.18);
+  color:#ffd59c;
+  border:1px solid rgba(244, 166, 75, 0.45);
+}
+
+.badge.offline {
+  background:rgba(138, 157, 197, 0.18);
+  color:#c9d6f1;
+  border:1px solid rgba(138, 157, 197, 0.45);
+}
+
+.panel-stack {
+  display:grid;
+  gap:18px;
+}
+
+.task-list {
+  margin:0;
+  padding:0;
+  list-style:none;
+  display:grid;
+  gap:10px;
+}
+
+.task-list li {
+  border:1px solid rgba(82, 105, 147, 0.72);
+  border-radius:12px;
+  padding:10px 12px;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  background:rgba(10, 22, 42, 0.8);
+}
+
+.task-list small {
+  color:#9eb3dd;
+  font-weight:600;
+}
+
+.team-areas {
+  display:grid;
+  grid-template-columns:repeat(5, minmax(0, 1fr));
+  gap:14px;
+}
+
+.area-card {
+  min-height:150px;
+  background:
+    linear-gradient(160deg, rgba(17, 30, 53, 0.95), rgba(12, 22, 39, 0.97)),
+    radial-gradient(120px 80px at 85% 0%, var(--mission-glow), transparent 70%);
+}
+
+.mission-tab:focus-visible,
+.node:focus-visible {
+  outline:2px solid #93b2ff;
+  outline-offset:2px;
+}
+
+@media (hover:hover) and (pointer:fine) {
+  .mission-tab:hover,
+  .mission-tab:focus-visible {
+    transform:translateY(-1px);
+    border-color:rgba(136, 166, 227, 0.92);
+    box-shadow:0 12px 22px rgba(2, 8, 20, 0.35);
+  }
+
+  .node:hover {
+    transform:translateY(-2px);
+    border-color:rgba(126, 160, 224, 0.94);
+    box-shadow:0 0 28px rgba(95, 141, 255, 0.2);
+  }
+}
+
+@media (max-width:1100px) {
+  .team-areas {
+    grid-template-columns:repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width:900px) {
+  .mission-grid {
+    grid-template-columns:1fr;
+  }
+
+  .node-row,
+  .node-row-small {
+    grid-template-columns:repeat(2, minmax(0, 1fr));
+  }
+
+  .org-canvas::before { inset:36px 8% auto; }
+}
+
+@media (max-width:700px) {
+  .mission-header-row {
+    flex-direction:column;
+  }
+
+  .node-row,
+  .node-row-small,
+  .team-areas {
+    grid-template-columns:1fr;
+  }
+
+  .node::before,
+  .node-row::before,
+  .org-canvas::before {
+    display:none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mission-tab,
+  .node {
+    transition:none;
+  }
+}

--- a/assets/js/mission-control.js
+++ b/assets/js/mission-control.js
@@ -1,0 +1,27 @@
+import { initRevealAnimations } from "./modules/reveal.js";
+import { updateYear } from "./modules/year.js";
+import { initHeaderCondense } from "./modules/interactions.js";
+
+function initMissionTabs() {
+  const tabs = Array.from(document.querySelectorAll(".mission-tab"));
+  if (!tabs.length) {
+    return;
+  }
+
+  tabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      tabs.forEach((entry) => {
+        entry.classList.remove("is-active");
+        entry.setAttribute("aria-selected", "false");
+      });
+
+      tab.classList.add("is-active");
+      tab.setAttribute("aria-selected", "true");
+    });
+  });
+}
+
+updateYear();
+initHeaderCondense();
+initRevealAnimations();
+initMissionTabs();

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
         <a href="#proof">Ergebnisse</a>
         <a href="#work">Selected Work</a>
         <a href="#process">Ablauf</a>
+        <a href="mission-control.html">Mission Control</a>
         <a href="#contact">Kontakt</a>
       </nav>
     </header>

--- a/mission-control.html
+++ b/mission-control.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="description" content="Mission Control Dashboard – Demo-Interface für Teamsteuerung, Aufgabenstatus und Bereichs-KPIs.">
+  <meta name="author" content="Hendrik Schneemann">
+  <meta name="theme-color" content="#070d1a">
+  <meta name="robots" content="index,follow">
+  <title>Mission Control · Dashboard Demo</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+  <link rel="stylesheet" href="assets/css/mission-control.css">
+</head>
+<body>
+  <a class="skip-link" href="#mission-main">Zum Inhalt springen</a>
+
+  <div class="wrap mission-wrap">
+    <header id="site-header">
+      <a class="brand" href="index.html" aria-label="Zur Startseite">
+        <b>Hendrik Schneemann</b>
+      </a>
+      <nav aria-label="Hauptnavigation">
+        <a href="index.html">Startseite</a>
+        <a href="mission-control.html" class="is-active" aria-current="page">Mission Control</a>
+      </nav>
+    </header>
+
+    <main id="mission-main" data-reveal-group>
+      <section class="mission-header card" data-reveal aria-labelledby="mission-heading">
+        <div class="mission-header-row">
+          <div>
+            <p class="eyebrow">Control Layer · Demo Environment</p>
+            <h1 id="mission-heading">Mission Control Dashboard</h1>
+            <p class="muted">Bilinguales Live-Board für Team-Flow, Prioritäten und aktive Workstreams.</p>
+          </div>
+          <span class="mission-pill">Systemstatus · Stabil</span>
+        </div>
+
+        <div class="mission-tabs" role="tablist" aria-label="Mission Bereiche">
+          <button class="mission-tab is-active" role="tab" aria-selected="true">Mission Control</button>
+          <button class="mission-tab" role="tab" aria-selected="false">Tasks</button>
+          <button class="mission-tab" role="tab" aria-selected="false">Chat</button>
+          <button class="mission-tab" role="tab" aria-selected="false">Memory</button>
+          <button class="mission-tab" role="tab" aria-selected="false">Signals</button>
+        </div>
+      </section>
+
+      <section class="mission-grid">
+        <article class="card org-map" data-reveal aria-labelledby="org-map-heading">
+          <div class="pad">
+            <div class="panel-head">
+              <h2 id="org-map-heading">Team-Orchestrierung · Org Map</h2>
+              <span class="badge online">3 live</span>
+            </div>
+
+            <div class="org-canvas" role="list" aria-label="Hierarchie Teamstruktur">
+              <div class="node node-core" role="listitem">
+                <p class="node-label">Core Command</p>
+                <h3>Control Lead</h3>
+                <span class="badge online">online</span>
+              </div>
+
+              <div class="node-row">
+                <div class="node" role="listitem">
+                  <p class="node-label">Delivery</p>
+                  <h3>Build Team</h3>
+                  <span class="badge busy">busy</span>
+                </div>
+                <div class="node" role="listitem">
+                  <p class="node-label">Operations</p>
+                  <h3>Flow Team</h3>
+                  <span class="badge online">online</span>
+                </div>
+                <div class="node" role="listitem">
+                  <p class="node-label">Insights</p>
+                  <h3>Signal Team</h3>
+                  <span class="badge offline">offline</span>
+                </div>
+              </div>
+
+              <div class="node-row node-row-small">
+                <div class="node mini" role="listitem">
+                  <p class="node-label">UX</p>
+                  <h3>Content Ops</h3>
+                </div>
+                <div class="node mini" role="listitem">
+                  <p class="node-label">API</p>
+                  <h3>Dev Relay</h3>
+                </div>
+                <div class="node mini" role="listitem">
+                  <p class="node-label">QA</p>
+                  <h3>Review Unit</h3>
+                </div>
+                <div class="node mini" role="listitem">
+                  <p class="node-label">PM</p>
+                  <h3>Product Desk</h3>
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+
+        <aside class="panel-stack" data-reveal-group>
+          <article class="card panel" data-reveal>
+            <div class="pad">
+              <div class="panel-head">
+                <h2>Aktive Prioritäten</h2>
+                <span class="badge busy">5 offen</span>
+              </div>
+              <ul class="task-list">
+                <li><span>Landing Iteration</span><small>Heute · 18:30</small></li>
+                <li><span>API Health Check</span><small>Heute · 20:00</small></li>
+                <li><span>Copy QA / DE+EN</span><small>Morgen · 09:00</small></li>
+              </ul>
+            </div>
+          </article>
+
+          <article class="card panel" data-reveal>
+            <div class="pad">
+              <div class="panel-head">
+                <h2>Live Chat Snapshot</h2>
+                <span class="badge online">2 threads</span>
+              </div>
+              <p class="muted">"Deploy-Fenster bestätigt."</p>
+              <p class="muted">"Content-Review in 15 Minuten."</p>
+            </div>
+          </article>
+        </aside>
+      </section>
+
+      <section class="team-areas" data-reveal-group aria-label="Bereichsübersicht">
+        <article class="card area-card" data-reveal>
+          <div class="pad">
+            <p class="eyebrow">Marketing</p>
+            <h3>Campaign Pulse</h3>
+            <p class="muted">Assets bereit · nächste Freigabe 19:00</p>
+          </div>
+        </article>
+
+        <article class="card area-card" data-reveal>
+          <div class="pad">
+            <p class="eyebrow">Development</p>
+            <h3>Build Stream</h3>
+            <p class="muted">2 Features aktiv · 1 Hotfix review</p>
+          </div>
+        </article>
+
+        <article class="card area-card" data-reveal>
+          <div class="pad">
+            <p class="eyebrow">Content</p>
+            <h3>Editorial Lane</h3>
+            <p class="muted">DE/EN Sync · Qualitätscheck läuft</p>
+          </div>
+        </article>
+
+        <article class="card area-card" data-reveal>
+          <div class="pad">
+            <p class="eyebrow">Product</p>
+            <h3>Roadmap Desk</h3>
+            <p class="muted">Q2 Ziele priorisiert · Discovery aktiv</p>
+          </div>
+        </article>
+
+        <article class="card area-card" data-reveal>
+          <div class="pad">
+            <p class="eyebrow">Sales</p>
+            <h3>Pipeline Radar</h3>
+            <p class="muted">3 qualifizierte Leads · Follow-up offen</p>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <footer>
+      <span>&copy; <span id="year"></span> Hendrik Schneemann · Mission Control Demo</span>
+      <span>Dark UI Prototype · HTML/CSS/JS</span>
+    </footer>
+  </div>
+
+  <script src="assets/js/mission-control.js" type="module"></script>
+</body>
+</html>

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -7,6 +7,7 @@
         <a href="#proof">Ergebnisse</a>
         <a href="#work">Selected Work</a>
         <a href="#process">Ablauf</a>
+        <a href="mission-control.html">Mission Control</a>
         <a href="#contact">Kontakt</a>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- add a new `mission-control.html` page with a dark, futuristic mission-control look and org-chart style structure
- include top tab bar (Mission Control, Tasks, Chat, Memory, Signals), hierarchy nodes, team area cards, and status badges
- wire microinteractions (tab selection, hover/focus states), reveal animations, and respect `prefers-reduced-motion`
- add Mission Control entry in homepage navigation via `src/partials/header.html` and rebuild `index.html`

## Architecture & Components
- **HTML structure:** dedicated page with modular sections (header panel, org map, priority/chat side panels, area cards)
- **Styling:** new `assets/css/mission-control.css` layered on top of existing global styles (`assets/css/styles.css`)
- **Behavior:** new lightweight `assets/js/mission-control.js` reusing existing modules (`reveal`, `year`, `header condense`) and adding tab state microinteraction
- **Build consistency:** homepage nav update made in source partial and generated with `./scripts/build-html.sh`

## Validation
- ran `./scripts/build-html.sh` successfully
