### PR TITLE
fix: Bug: Headerbar-Navigation markiert mehrere Pills gleichzeitig als aktiv

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -44,10 +44,12 @@ nav a {
   transition:background-color .2s ease, border-color .2s ease, color .2s ease;
 }
 
-nav a:hover {
-  color:var(--text);
-  border-color:rgba(126, 163, 255, 0.38);
-  background:rgba(95, 141, 255, 0.14);
+@media (hover:hover) and (pointer:fine) {
+  nav a:hover {
+    color:var(--text);
+    border-color:rgba(126, 163, 255, 0.38);
+    background:rgba(95, 141, 255, 0.14);
+  }
 }
 
 nav a.is-active {


### PR DESCRIPTION
## Summary
- behebt den mehrfachen aktiv wirkenden Zustand in der mobilen Headerbar-Navigation
- begrenzt den `:hover`-Pill-Style auf Geräte mit echter Hover-Unterstützung (Maus/Trackpad)
- verhindert dadurch den auf Touch-Geräten klebenden Hover-State, der zusammen mit `.is-active` wie mehrere aktive Pills aussieht

## Changes
- `assets/css/layout.css`
  - `nav a:hover` in `@media (hover:hover) and (pointer:fine)` gekapselt

## Testing
- `./scripts/build-html.sh`
- visuelle Prüfung vorgesehen für Mobile (Touch): nur ein aktiver Navigationspunkt gleichzeitig

Fixes hsnowmansch/hschneemannWebsite#17