### PR TITLE
fix: reduce CTA friction with booking-first contact intent

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,6 +4,7 @@ import { initRevealAnimations } from "./modules/reveal.js";
 import { updateYear } from "./modules/year.js";
 import { initHeaderCondense, initHeroParallax, initScrollNavigation } from "./modules/interactions.js";
 import { initConversionTracking, initMobileStickyCtaTracking } from "./modules/tracking.js";
+import { initLeadTracking } from "./modules/lead-tracking.js";
 
 updateYear();
 wireOptionalLink("appsLink", LINKS.linktreeOrApps);
@@ -14,3 +15,4 @@ initHeroParallax();
 initScrollNavigation();
 initConversionTracking();
 initMobileStickyCtaTracking();
+initLeadTracking();

--- a/assets/js/modules/lead-tracking.js
+++ b/assets/js/modules/lead-tracking.js
@@ -1,0 +1,42 @@
+function emitAnalyticsEvent(eventName, params = {}) {
+  if (!eventName) {
+    return;
+  }
+
+  if (typeof window.gtag === "function") {
+    window.gtag("event", eventName, params);
+  }
+
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({ event: eventName, ...params });
+
+  window.dispatchEvent(
+    new CustomEvent("lead:event", {
+      detail: { eventName, params }
+    })
+  );
+}
+
+export function initLeadTracking() {
+  const startCtas = document.querySelectorAll("[data-lead-start]");
+  const submitCtas = document.querySelectorAll("[data-lead-submit]");
+
+  startCtas.forEach((element) => {
+    element.addEventListener("click", () => {
+      emitAnalyticsEvent("lead_started", {
+        source: element.dataset.leadStart || "unknown",
+        target: element.getAttribute("href") || ""
+      });
+    });
+  });
+
+  submitCtas.forEach((element) => {
+    element.addEventListener("click", () => {
+      emitAnalyticsEvent("lead_submitted", {
+        method: element.dataset.leadSubmit || "unknown",
+        source: element.dataset.leadStart || "unknown",
+        target: element.getAttribute("href") || ""
+      });
+    });
+  });
+}

--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
     </section>
 
     <footer>
-      <span>&copy; <span id="year"></span> Hendrik Schneemann · vmain.2-08bcd01</span>
+      <span>&copy; <span id="year"></span> Hendrik Schneemann · vc6ac664</span>
       <nav class="footer-links" aria-label="Rechtliche Hinweise">
         <a href="#impressum">Impressum</a>
         <a href="#datenschutz">Datenschutz</a>


### PR DESCRIPTION
## Summary
- switch Hero primary CTA to a booking-first scoping-call intent
- align Hero + Kontakt primary CTA to the same target path (`mailto` with booking subject)
- keep phone/linkedin as optional secondary CTAs in Kontakt
- add measurable `lead_started` + `lead_submitted` events for lead flow interactions

## Testing
- `node --check assets/js/main.js`
- `node --check assets/js/modules/lead-tracking.js`

Fixes #7