### PR TITLE
fix: [Website Review] Mobile Navigation entlasten (sticky Header + viele Links)

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -262,7 +262,8 @@
 
 nav a:focus-visible,
 .btn:focus-visible,
-.brand:focus-visible {
+.brand:focus-visible,
+.menu-toggle:focus-visible {
   outline:2px solid #93b2ff;
   outline-offset:2px;
 }

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -21,6 +21,10 @@ header {
   transition:padding .24s ease, background-color .24s ease, box-shadow .24s ease;
 }
 
+.menu-toggle {
+  display:none;
+}
+
 header.is-condensed {
   padding:10px 14px;
   background:rgba(9, 15, 30, 0.9);
@@ -45,6 +49,10 @@ nav a {
   font-size:0.92rem;
   border:1px solid transparent;
   transition:background-color .2s ease, border-color .2s ease, color .2s ease;
+}
+
+nav.is-open {
+  display:flex;
 }
 
 @media (hover:hover) and (pointer:fine) {
@@ -180,6 +188,49 @@ footer {
   .proof-grid,
   .conversion-pad {
     grid-template-columns:1fr;
+  }
+}
+
+@media (max-width:760px) {
+  header {
+    min-height:56px;
+  }
+
+  .menu-toggle {
+    display:inline-flex;
+    align-items:center;
+    justify-content:center;
+    gap:8px;
+    padding:8px 12px;
+    border-radius:10px;
+    border:1px solid rgba(134, 162, 221, 0.5);
+    background:rgba(13, 23, 42, 0.95);
+    color:#eff4ff;
+    font-weight:700;
+    font-size:0.9rem;
+  }
+
+  nav {
+    position:absolute;
+    top:calc(100% + 8px);
+    left:0;
+    right:0;
+    display:none;
+    flex-direction:column;
+    gap:6px;
+    padding:10px;
+    border-radius:14px;
+    border:1px solid rgba(78, 98, 132, 0.9);
+    background:rgba(9, 15, 30, 0.98);
+    box-shadow:0 16px 32px rgba(0, 0, 0, 0.35);
+  }
+
+  nav a {
+    width:100%;
+  }
+
+  body.menu-open {
+    overflow:hidden;
   }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2,7 +2,7 @@ import { LINKS } from "./config.js";
 import { wireOptionalLink } from "./modules/links.js";
 import { initRevealAnimations } from "./modules/reveal.js";
 import { updateYear } from "./modules/year.js";
-import { initHeaderCondense, initHeroParallax, initScrollNavigation } from "./modules/interactions.js";
+import { initHeaderCondense, initHeroParallax, initMobileNavigation, initScrollNavigation } from "./modules/interactions.js";
 import { initConversionTracking, initMobileStickyCtaTracking } from "./modules/tracking.js";
 import { initLeadTracking } from "./modules/lead-tracking.js";
 
@@ -12,6 +12,7 @@ wireOptionalLink("linkedinLink", LINKS.linkedin);
 initRevealAnimations();
 initHeaderCondense();
 initHeroParallax();
+initMobileNavigation();
 initScrollNavigation();
 initConversionTracking();
 initMobileStickyCtaTracking();

--- a/assets/js/modules/interactions.js
+++ b/assets/js/modules/interactions.js
@@ -45,6 +45,123 @@ export function initHeroParallax() {
   update();
 }
 
+export function initMobileNavigation() {
+  const header = document.getElementById("site-header");
+  const nav = document.getElementById("primary-nav");
+  const toggle = header?.querySelector(".menu-toggle");
+  const navLinks = nav ? Array.from(nav.querySelectorAll("a")) : [];
+
+  if (!header || !nav || !toggle || !navLinks.length) {
+    return;
+  }
+
+  const media = window.matchMedia("(max-width: 760px)");
+  let lastFocused = null;
+
+  const focusableSelector =
+    "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])";
+
+  const isOpen = () => nav.classList.contains("is-open");
+
+  const openMenu = () => {
+    lastFocused = document.activeElement;
+    nav.classList.add("is-open");
+    document.body.classList.add("menu-open");
+    toggle.setAttribute("aria-expanded", "true");
+    toggle.setAttribute("aria-label", "Menü schließen");
+
+    const firstLink = navLinks[0];
+    firstLink?.focus();
+  };
+
+  const closeMenu = ({ restoreFocus = true } = {}) => {
+    nav.classList.remove("is-open");
+    document.body.classList.remove("menu-open");
+    toggle.setAttribute("aria-expanded", "false");
+    toggle.setAttribute("aria-label", "Menü öffnen");
+
+    if (restoreFocus && lastFocused instanceof HTMLElement) {
+      lastFocused.focus();
+    }
+  };
+
+  const onToggleClick = () => {
+    if (isOpen()) {
+      closeMenu();
+      return;
+    }
+
+    openMenu();
+  };
+
+  const onDocumentClick = (event) => {
+    if (!media.matches || !isOpen()) {
+      return;
+    }
+
+    const target = event.target;
+    if (!(target instanceof Node)) {
+      return;
+    }
+
+    if (!header.contains(target)) {
+      closeMenu({ restoreFocus: false });
+    }
+  };
+
+  const onKeydown = (event) => {
+    if (!media.matches || !isOpen()) {
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeMenu();
+      return;
+    }
+
+    if (event.key !== "Tab") {
+      return;
+    }
+
+    const focusables = Array.from(nav.querySelectorAll(focusableSelector));
+    if (!focusables.length) {
+      return;
+    }
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const onMediaChange = () => {
+    if (!media.matches) {
+      closeMenu({ restoreFocus: false });
+      nav.style.removeProperty("display");
+    }
+  };
+
+  toggle.addEventListener("click", onToggleClick);
+  document.addEventListener("click", onDocumentClick);
+  document.addEventListener("keydown", onKeydown);
+  media.addEventListener("change", onMediaChange);
+  navLinks.forEach((link) => {
+    link.addEventListener("click", () => {
+      if (media.matches) {
+        closeMenu({ restoreFocus: false });
+      }
+    });
+  });
+}
+
 export function initScrollNavigation() {
   const navLinks = Array.from(document.querySelectorAll("nav a[href^='#']"));
   if (!navLinks.length) {

--- a/index.html
+++ b/index.html
@@ -28,7 +28,16 @@
       <a class="brand" href="#top" aria-label="Zur Startseite">
         <b>Hendrik Schneemann</b>
       </a>
-      <nav aria-label="Hauptnavigation">
+      <button
+        class="menu-toggle"
+        type="button"
+        aria-expanded="false"
+        aria-controls="primary-nav"
+        aria-label="Menü öffnen"
+      >
+        Menü
+      </button>
+      <nav id="primary-nav" aria-label="Hauptnavigation">
         <a href="#offer">Angebot</a>
         <a href="#proof">Ergebnisse</a>
         <a href="#work">Selected Work</a>
@@ -342,7 +351,7 @@
     </section>
 
     <footer>
-      <span>&copy; <span id="year"></span> Hendrik Schneemann · vmain.3-7a12252</span>
+      <span>&copy; <span id="year"></span> Hendrik Schneemann · vb498fd4</span>
       <nav class="footer-links" aria-label="Rechtliche Hinweise">
         <a href="#impressum">Impressum</a>
         <a href="#datenschutz">Datenschutz</a>

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -2,7 +2,16 @@
       <a class="brand" href="#top" aria-label="Zur Startseite">
         <b>Hendrik Schneemann</b>
       </a>
-      <nav aria-label="Hauptnavigation">
+      <button
+        class="menu-toggle"
+        type="button"
+        aria-expanded="false"
+        aria-controls="primary-nav"
+        aria-label="Menü öffnen"
+      >
+        Menü
+      </button>
+      <nav id="primary-nav" aria-label="Hauptnavigation">
         <a href="#offer">Angebot</a>
         <a href="#proof">Ergebnisse</a>
         <a href="#work">Selected Work</a>


### PR DESCRIPTION
## Summary
- add a compact mobile menu toggle to keep the sticky header one-line on small viewports
- render navigation links in a dropdown panel on mobile while keeping desktop nav unchanged
- add keyboard/screenreader behavior: `aria-expanded`, `aria-controls`, escape-to-close, and focus trap while menu is open

## Validation
- `./scripts/build-html.sh`

Fixes #8