### PR TITLE
fix: [Website Review] Render-Blocking durch Google-Font-Import minimieren

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap");
+/* Fonts are loaded in index.html via preconnect + stylesheet to avoid render-blocking CSS @import. */
 
 :root {
   --bg:#070d1a;

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
   <meta property="twitter:title" content="Hendrik Schneemann · Entwickler">
   <meta property="twitter:description" content="iOS- und Backend-Entwicklung mit Fokus auf modulare, wartbare und produktionsnahe Software.">
   <title>Hendrik Schneemann · Entwickler</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap">
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary

Google Fonts wurden aus dem render-blocking CSS-@import entfernt und stattdessen im HTML-Head mit preconnect + stylesheet eingebunden. Damit startet der Font-Fetch früher und blockiert den CSS-Parse-Pfad nicht mehr.

## Changes

- Entfernt: `@import` zu `fonts.googleapis.com` aus `assets/css/base.css`
- Hinzugefügt: `preconnect` auf `fonts.googleapis.com` und `fonts.gstatic.com` in `index.html`
- Hinzugefügt: Google Fonts Stylesheet-Link im `<head>` mit `display=swap`

## Testing

- Verifiziert, dass kein Google-Font-`@import` mehr in CSS vorhanden ist
- Statischer Build (keine automatisierte Test-Suite im Repo vorhanden)

Fixes hsnowmansch/hschneemannWebsite#9