### PR TITLE
fix: [Website Research] Developer-Positioning über problemorientierte Segmente schärfen

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -260,6 +260,28 @@
 
 .showcase h3 { margin-bottom:8px; }
 
+.segment-jump-links {
+  margin-top:10px;
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+}
+
+.segment-jump-links a {
+  text-decoration:none;
+  font-weight:600;
+  font-size:0.84rem;
+  padding:6px 10px;
+  border-radius:999px;
+  color:#d8e3fb;
+  border:1px solid rgba(83, 106, 146, 0.88);
+  background:rgba(15, 29, 53, 0.86);
+}
+
+.segment-card .muted strong {
+  color:#dce6fc;
+}
+
 nav a:focus-visible,
 .btn:focus-visible,
 .brand:focus-visible,

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -101,6 +101,13 @@ section { margin-top:42px; }
   gap:20px;
 }
 
+.segment-grid {
+  margin-top:16px;
+  display:grid;
+  grid-template-columns:repeat(3, minmax(0, 1fr));
+  gap:14px;
+}
+
 .showcase-grid {
   display:grid;
   grid-template-columns:repeat(3, minmax(0, 1fr));
@@ -183,6 +190,7 @@ footer {
   .hero-shell,
   .value-grid,
   .offer-grid,
+  .segment-grid,
   .showcase-grid,
   .grid,
   .proof-grid,

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -17,3 +17,29 @@ initScrollNavigation();
 initConversionTracking();
 initMobileStickyCtaTracking();
 initLeadTracking();
+
+const trackSegmentClick = (segmentId) => {
+  const payload = {
+    event: "segment_cta_click",
+    segment_id: segmentId,
+  };
+
+  if (Array.isArray(window.dataLayer)) {
+    window.dataLayer.push(payload);
+  }
+
+  if (typeof window.gtag === "function") {
+    window.gtag("event", "segment_cta_click", {
+      segment_id: segmentId,
+    });
+  }
+};
+
+document.querySelectorAll(".segment-cta[data-segment-id]").forEach((element) => {
+  element.addEventListener("click", () => {
+    const segmentId = element.getAttribute("data-segment-id");
+    if (!segmentId) return;
+
+    trackSegmentClick(segmentId);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
         Menü
       </button>
       <nav id="primary-nav" aria-label="Hauptnavigation">
+        <a href="#segments">Problem-Segmente</a>
         <a href="#offer">Angebot</a>
         <a href="#proof">Ergebnisse</a>
         <a href="#work">Selected Work</a>
@@ -128,6 +129,74 @@
           <li>PHP / Symfony</li>
           <li>Sentry &amp; Analytics</li>
         </ul>
+      </section>
+
+      <section id="segments" class="segments" aria-labelledby="segments-heading" data-reveal-group>
+        <div class="section-head" data-reveal>
+          <p class="eyebrow">Developer Positioning</p>
+          <h2 id="segments-heading">Wähle den Problemraum, der euch gerade bremst</h2>
+          <div class="segment-jump-links" aria-label="Direkte Sprunglinks zu Problem-Segmenten">
+            <a href="#segment-release-stau">Release-Stau im iOS-Team</a>
+            <a href="#segment-legacy-mix">Legacy UIKit/SwiftUI-Mischbetrieb</a>
+            <a href="#segment-app-backend-gap">App + Backend Delivery-Lücke</a>
+          </div>
+        </div>
+
+        <div class="segment-grid">
+          <article class="card segment-card" id="segment-release-stau" data-reveal>
+            <div class="pad">
+              <p class="value-label">Segment 01</p>
+              <h3>Release-Stau im iOS-Team</h3>
+              <p class="muted"><strong>Symptom:</strong> Features bleiben zu lange in Review und Releases verschieben sich sprintübergreifend.</p>
+              <p class="muted"><strong>Kosten des Nicht-Handelns:</strong> Verpasste Learnings, steigender Stakeholder-Druck und sinkende Team-Moral.</p>
+              <ul class="clean-list">
+                <li>2–3 Wochen klarer Delivery-Plan statt Ad-hoc-Priorisierung</li>
+                <li>Kürzere Durchlaufzeit von Ticket bis produktivem Release</li>
+                <li>Transparente Weekly-Outcomes für Product und Management</li>
+              </ul>
+              <p class="muted">Proof: <a href="#case-cityapp">CityApp Case</a> zeigt iOS-Lead + Teamkoordination.</p>
+              <div class="cta">
+                <a class="btn primary segment-cta" data-segment-id="release-stau" href="#contact">Release-Stau im Gespräch lösen</a>
+              </div>
+            </div>
+          </article>
+
+          <article class="card segment-card" id="segment-legacy-mix" data-reveal>
+            <div class="pad">
+              <p class="value-label">Segment 02</p>
+              <h3>Legacy UIKit/SwiftUI-Mischbetrieb</h3>
+              <p class="muted"><strong>Symptom:</strong> Neue Features dauern, weil UIKit-Altlasten und SwiftUI-Module unklar verzahnt sind.</p>
+              <p class="muted"><strong>Kosten des Nicht-Handelns:</strong> Höhere Bug-Rate, langsameres Onboarding und wachsender Refactor-Backlog.</p>
+              <ul class="clean-list">
+                <li>Pragmatische Migrationspfade ohne Big-Bang-Risiko</li>
+                <li>Klare Modulgrenzen für bessere Wartbarkeit</li>
+                <li>Stabilere Releases trotz gemischtem Stack</li>
+              </ul>
+              <p class="muted">Proof: <a href="#case-cityapp">CityApp Case</a> mit modularer SwiftUI-Struktur und Skalierungsfokus.</p>
+              <div class="cta">
+                <a class="btn primary segment-cta" data-segment-id="legacy-mix" href="#contact">Legacy-Mix strukturiert modernisieren</a>
+              </div>
+            </div>
+          </article>
+
+          <article class="card segment-card" id="segment-app-backend-gap" data-reveal>
+            <div class="pad">
+              <p class="value-label">Segment 03</p>
+              <h3>App + Backend Delivery-Lücke</h3>
+              <p class="muted"><strong>Symptom:</strong> iOS und Backend liefern asynchron, Integrationen brechen spät im Prozess.</p>
+              <p class="muted"><strong>Kosten des Nicht-Handelns:</strong> Teure Nacharbeiten kurz vor Release und unklare Verantwortlichkeiten im Team.</p>
+              <ul class="clean-list">
+                <li>Abgestimmte API- und App-Inkremente pro Sprint</li>
+                <li>Frühere Integrationstests für weniger Last-Minute-Fixes</li>
+                <li>Einheitliche Ownership über Frontend und Backend hinweg</li>
+              </ul>
+              <p class="muted">Proof: <a href="#case-muellapp">Müllapp Case</a> mit UIKit-Frontend und PHP-Backend aus einer Hand.</p>
+              <div class="cta">
+                <a class="btn primary segment-cta" data-segment-id="app-backend-gap" href="#contact">Delivery-Lücke gemeinsam schließen</a>
+              </div>
+            </div>
+          </article>
+        </div>
       </section>
     </main>
     <section id="offer" class="value-grid" aria-labelledby="offer-heading" data-reveal-group>
@@ -351,7 +420,7 @@
     </section>
 
     <footer>
-      <span>&copy; <span id="year"></span> Hendrik Schneemann · vmain.4-4968910</span>
+      <span>&copy; <span id="year"></span> Hendrik Schneemann · v10cf6b5</span>
       <nav class="footer-links" aria-label="Rechtliche Hinweise">
         <a href="#impressum">Impressum</a>
         <a href="#datenschutz">Datenschutz</a>

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -12,6 +12,7 @@
         Menü
       </button>
       <nav id="primary-nav" aria-label="Hauptnavigation">
+        <a href="#segments">Problem-Segmente</a>
         <a href="#offer">Angebot</a>
         <a href="#proof">Ergebnisse</a>
         <a href="#work">Selected Work</a>

--- a/src/partials/hero.html
+++ b/src/partials/hero.html
@@ -81,4 +81,72 @@
           <li>Sentry &amp; Analytics</li>
         </ul>
       </section>
+
+      <section id="segments" class="segments" aria-labelledby="segments-heading" data-reveal-group>
+        <div class="section-head" data-reveal>
+          <p class="eyebrow">Developer Positioning</p>
+          <h2 id="segments-heading">Wähle den Problemraum, der euch gerade bremst</h2>
+          <div class="segment-jump-links" aria-label="Direkte Sprunglinks zu Problem-Segmenten">
+            <a href="#segment-release-stau">Release-Stau im iOS-Team</a>
+            <a href="#segment-legacy-mix">Legacy UIKit/SwiftUI-Mischbetrieb</a>
+            <a href="#segment-app-backend-gap">App + Backend Delivery-Lücke</a>
+          </div>
+        </div>
+
+        <div class="segment-grid">
+          <article class="card segment-card" id="segment-release-stau" data-reveal>
+            <div class="pad">
+              <p class="value-label">Segment 01</p>
+              <h3>Release-Stau im iOS-Team</h3>
+              <p class="muted"><strong>Symptom:</strong> Features bleiben zu lange in Review und Releases verschieben sich sprintübergreifend.</p>
+              <p class="muted"><strong>Kosten des Nicht-Handelns:</strong> Verpasste Learnings, steigender Stakeholder-Druck und sinkende Team-Moral.</p>
+              <ul class="clean-list">
+                <li>2–3 Wochen klarer Delivery-Plan statt Ad-hoc-Priorisierung</li>
+                <li>Kürzere Durchlaufzeit von Ticket bis produktivem Release</li>
+                <li>Transparente Weekly-Outcomes für Product und Management</li>
+              </ul>
+              <p class="muted">Proof: <a href="#case-cityapp">CityApp Case</a> zeigt iOS-Lead + Teamkoordination.</p>
+              <div class="cta">
+                <a class="btn primary segment-cta" data-segment-id="release-stau" href="#contact">Release-Stau im Gespräch lösen</a>
+              </div>
+            </div>
+          </article>
+
+          <article class="card segment-card" id="segment-legacy-mix" data-reveal>
+            <div class="pad">
+              <p class="value-label">Segment 02</p>
+              <h3>Legacy UIKit/SwiftUI-Mischbetrieb</h3>
+              <p class="muted"><strong>Symptom:</strong> Neue Features dauern, weil UIKit-Altlasten und SwiftUI-Module unklar verzahnt sind.</p>
+              <p class="muted"><strong>Kosten des Nicht-Handelns:</strong> Höhere Bug-Rate, langsameres Onboarding und wachsender Refactor-Backlog.</p>
+              <ul class="clean-list">
+                <li>Pragmatische Migrationspfade ohne Big-Bang-Risiko</li>
+                <li>Klare Modulgrenzen für bessere Wartbarkeit</li>
+                <li>Stabilere Releases trotz gemischtem Stack</li>
+              </ul>
+              <p class="muted">Proof: <a href="#case-cityapp">CityApp Case</a> mit modularer SwiftUI-Struktur und Skalierungsfokus.</p>
+              <div class="cta">
+                <a class="btn primary segment-cta" data-segment-id="legacy-mix" href="#contact">Legacy-Mix strukturiert modernisieren</a>
+              </div>
+            </div>
+          </article>
+
+          <article class="card segment-card" id="segment-app-backend-gap" data-reveal>
+            <div class="pad">
+              <p class="value-label">Segment 03</p>
+              <h3>App + Backend Delivery-Lücke</h3>
+              <p class="muted"><strong>Symptom:</strong> iOS und Backend liefern asynchron, Integrationen brechen spät im Prozess.</p>
+              <p class="muted"><strong>Kosten des Nicht-Handelns:</strong> Teure Nacharbeiten kurz vor Release und unklare Verantwortlichkeiten im Team.</p>
+              <ul class="clean-list">
+                <li>Abgestimmte API- und App-Inkremente pro Sprint</li>
+                <li>Frühere Integrationstests für weniger Last-Minute-Fixes</li>
+                <li>Einheitliche Ownership über Frontend und Backend hinweg</li>
+              </ul>
+              <p class="muted">Proof: <a href="#case-muellapp">Müllapp Case</a> mit UIKit-Frontend und PHP-Backend aus einer Hand.</p>
+              <div class="cta">
+                <a class="btn primary segment-cta" data-segment-id="app-backend-gap" href="#contact">Delivery-Lücke gemeinsam schließen</a>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
     </main>


### PR DESCRIPTION
## Summary

Die Landingpage wurde um drei klar benannte, problemorientierte Developer-Segmente erweitert, damit Inbound-Entscheider:innen schneller erkennen, ob das Angebot zu ihrer Situation passt. Jedes Segment enthält Symptom, Kosten des Nicht-Handelns, konkrete Outcomes, segment-spezifischen CTA und einen Proof-Verweis auf passende Cases. Zusätzlich werden Segment-CTA-Klicks als `segment_cta_click` mit `segment_id` getrackt.

## Changes

- Neue Sektion `#segments` mit 3 Problem-Segmenten ergänzt:
  - Release-Stau im iOS-Team
  - Legacy UIKit/SwiftUI-Mischbetrieb
  - App + Backend Delivery-Lücke
- In-Page-Sprunglinks zu allen Segmenten ergänzt
- Header-Navigation um direkten Link zu den Problem-Segmenten erweitert
- Segment-spezifische CTA-Buttons inkl. Tracking-Attribut `data-segment-id` ergänzt
- Case-/Proof-Verlinkungen zu `#case-cityapp` und `#case-muellapp` implementiert
- JavaScript-Tracking ergänzt: Event `segment_cta_click` via `dataLayer` und `gtag`
- Styles für Segment-Grid und Jump-Links ergänzt

## Testing

- Kein formales Test-Framework im Repository vorhanden (kein package.json/pytest/Makefile)
- Statischer Build erfolgreich ausgeführt: `./scripts/build-html.sh`
- Verifiziert, dass Segment-IDs, Jump-Links, Case-Anker und Tracking-Hook in `index.html` vorhanden sind

Fixes hsnowmansch/hschneemannWebsite#16