### PR TITLE
fix: mobile sticky bottom CTA and touch target hygiene

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -74,6 +74,7 @@
   justify-content:center;
   gap:8px;
   padding:11px 16px;
+  min-height:44px;
   border-radius:12px;
   border:1px solid rgba(80, 104, 143, 0.92);
   text-decoration:none;
@@ -285,6 +286,31 @@ nav a:focus-visible,
   .hero-pad { padding:24px 20px; }
   .cta .btn { flex:1 1 100%; }
   .trust-strip { gap:10px; }
+}
+
+.mobile-sticky-cta {
+  display:none;
+}
+
+@media (max-width:768px) {
+  .mobile-sticky-cta {
+    position:fixed;
+    left:12px;
+    right:12px;
+    bottom:max(12px, env(safe-area-inset-bottom));
+    z-index:90;
+    display:block;
+  }
+
+  .mobile-sticky-cta .btn {
+    width:100%;
+    min-height:48px;
+    box-shadow:0 10px 24px rgba(2, 7, 20, 0.35);
+  }
+
+  .hero-pad .cta .btn {
+    min-height:44px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -36,6 +36,9 @@ nav {
 nav a {
   text-decoration:none;
   padding:8px 12px;
+  min-height:44px;
+  display:inline-flex;
+  align-items:center;
   border-radius:999px;
   color:var(--muted);
   font-weight:600;
@@ -181,7 +184,7 @@ footer {
 }
 
 @media (max-width:700px) {
-  .wrap { padding:18px 14px 60px; }
+  .wrap { padding:18px 14px calc(60px + 84px); }
   header {
     margin-bottom:20px;
     top:6px;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,7 +3,7 @@ import { wireOptionalLink } from "./modules/links.js";
 import { initRevealAnimations } from "./modules/reveal.js";
 import { updateYear } from "./modules/year.js";
 import { initHeaderCondense, initHeroParallax, initScrollNavigation } from "./modules/interactions.js";
-import { initConversionTracking } from "./modules/tracking.js";
+import { initConversionTracking, initMobileStickyCtaTracking } from "./modules/tracking.js";
 
 updateYear();
 wireOptionalLink("appsLink", LINKS.linktreeOrApps);
@@ -13,3 +13,4 @@ initHeaderCondense();
 initHeroParallax();
 initScrollNavigation();
 initConversionTracking();
+initMobileStickyCtaTracking();

--- a/assets/js/modules/tracking.js
+++ b/assets/js/modules/tracking.js
@@ -1,4 +1,6 @@
 function emitTrack(eventName, payload = {}) {
+  if (!eventName) return;
+
   const data = {
     event: eventName,
     timestamp: new Date().toISOString(),
@@ -7,6 +9,10 @@ function emitTrack(eventName, payload = {}) {
 
   if (Array.isArray(window.dataLayer)) {
     window.dataLayer.push(data);
+  } else if (typeof window.gtag === "function") {
+    window.gtag("event", eventName, payload);
+  } else if (typeof window.plausible === "function") {
+    window.plausible(eventName, { props: payload });
   }
 
   window.dispatchEvent(new CustomEvent("hs-track", { detail: data }));
@@ -23,13 +29,22 @@ export function initConversionTracking() {
 
   document.querySelectorAll(".decision-faq details[data-faq-question]").forEach((entry) => {
     entry.addEventListener("toggle", () => {
-      if (!entry.open) {
-        return;
-      }
-
+      if (!entry.open) return;
       emitTrack("faq_expand", {
         question: entry.dataset.faqQuestion
       });
     });
   });
+}
+
+export function initMobileStickyCtaTracking() {
+  const cta = document.querySelector("#mobileStickyCta");
+  if (!cta || !window.matchMedia("(max-width: 768px)").matches) return;
+
+  emitTrack("mobile_sticky_cta_impression");
+  cta.addEventListener(
+    "click",
+    () => emitTrack("mobile_sticky_cta_click"),
+    { passive: true }
+  );
 }

--- a/index.html
+++ b/index.html
@@ -416,6 +416,10 @@
     </footer>
   </div>
 
+  <div class="mobile-sticky-cta" aria-label="Schneller Kontakt" data-mobile-sticky-cta>
+    <a class="btn primary" id="mobileStickyCta" href="#contact">Projektgespräch buchen</a>
+  </div>
+
   <script src="assets/js/main.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Adds a mobile-only sticky bottom CTA for low-friction contact entry and aligns key above-the-fold touch targets with mobile accessibility sizing.

## Changes
- Added persistent mobile sticky bottom CTA (`Projektgespräch buchen`) that links to `#contact` (same flow as hero primary CTA)
- Added mobile spacing reserve so content is not obscured by the sticky CTA
- Ensured key interactive targets meet minimum touch size expectations (`.btn` and mobile nav links)
- Added tracking hooks for `mobile_sticky_cta_impression` and `mobile_sticky_cta_click` with graceful support for `dataLayer`, `gtag`, or `plausible`

## Testing
- `node --check assets/js/main.js`
- `node --check assets/js/modules/tracking.js`

Fixes hsnowmansch/hschneemannWebsite#15