### PR TITLE
feat: Add structured data (Person/Service) for better discoverability

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,67 @@
   <meta property="twitter:description" content="iOS- und Backend-Entwicklung mit Fokus auf modulare, wartbare und produktionsnahe Software.">
   <title>Hendrik Schneemann · Entwickler</title>
   <link rel="stylesheet" href="assets/css/styles.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Hendrik Schneemann",
+  "url": "https://hendrikschneemann.tech",
+  "jobTitle": "Fachinformatiker für Anwendungsentwicklung",
+  "description": "iOS- und Backend-Entwicklung mit Fokus auf modulare, wartbare und produktionsnahe Software.",
+  "knowsAbout": [
+    "Swift",
+    "SwiftUI",
+    "UIKit",
+    "iOS Development",
+    "PHP",
+    "Symfony",
+    "Backend Development",
+    "API Design",
+    "Mobile App Development",
+    "Software Architecture"
+  ],
+  "sameAs": [
+    "https://www.linkedin.com/in/hendrik-schneemann"
+  ],
+  "worksFor": {
+    "@type": "Organization",
+    "name": "Hendrik Schneemann - Freelance Developer"
+  },
+  "makesOffer": [
+    {
+      "@type": "Service",
+      "name": "Build Sprint",
+      "description": "2-Wochen-Sprint für Features, die sauber geplant und schnell live gebracht werden müssen. Scoping, technischer Delivery-Plan, Umsetzung inkl. QA-Loop und Release-Readiness Checkliste.",
+      "provider": {
+        "@type": "Person",
+        "name": "Hendrik Schneemann"
+      },
+      "areaServed": "DE"
+    },
+    {
+      "@type": "Service",
+      "name": "Stabilize & Scale",
+      "description": "Laufende Betreuung für bestehende Apps mit Performance-, Architektur- oder Release-Problemen. Architektur-Audit, Refactoring kritischer Pfade und Observability mit Sentry/Logs.",
+      "provider": {
+        "@type": "Person",
+        "name": "Hendrik Schneemann"
+      },
+      "areaServed": "DE"
+    },
+    {
+      "@type": "Service",
+      "name": "Fractional Senior Developer",
+      "description": "Wöchentliche technische Begleitung für Teams als verlässlicher Sparringspartner auf Senior-Niveau. Code Reviews, technische Leitplanken und enge Abstimmung mit Product/Design.",
+      "provider": {
+        "@type": "Person",
+        "name": "Hendrik Schneemann"
+      },
+      "areaServed": "DE"
+    }
+  ]
+}
+</script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Zum Inhalt springen</a>


### PR DESCRIPTION
## Summary

Adds JSON-LD structured data markup following schema.org Person and Service types to improve search engine visibility and entity understanding.

## Changes

- Added JSON-LD Person schema in page head
- Included professional service offerings as Service entities
  - Build Sprint (2-week delivery package)
  - Stabilize & Scale (ongoing support)
  - Fractional Senior Developer (weekly engagement)
- Follows Google Search Central structured data guidelines
- Valid JSON structure with proper schema.org context

## Schema Details

**Person Schema:**
- name: Hendrik Schneemann
- jobTitle: Fachinformatiker für Anwendungsentwicklung
- knowsAbout: Swift, SwiftUI, UIKit, iOS Development, PHP, Symfony, etc.
- sameAs: LinkedIn profile

**Service Schema:**
- 3 distinct service offerings with descriptions
- Each linked to the Person entity

## Testing

- HTML validates without errors
- JSON-LD structure follows schema.org specifications
- JSON syntax validated via Node.js
- Ready for Google Rich Results Test validation

Fixes #14