### PR TITLE
fix: CTA-Entscheidungshilfe mit FAQ und Conversion-Tracking

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -91,6 +91,50 @@
 
 .btn:active { transform:translateY(1px) scale(.99); }
 
+.response-time {
+  margin:14px 0 0;
+  color:#d6e2f8;
+  font-size:0.95rem;
+}
+
+.response-time strong {
+  color:#fff;
+}
+
+.decision-faq {
+  margin-top:16px;
+  display:grid;
+  gap:10px;
+}
+
+.decision-faq-title {
+  margin:0;
+  color:#9cb1d9;
+  font-weight:700;
+  font-size:0.8rem;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+}
+
+.decision-faq details {
+  border:1px solid rgba(78, 100, 138, 0.8);
+  border-radius:12px;
+  background:rgba(15, 27, 48, 0.72);
+  padding:10px 12px;
+}
+
+.decision-faq summary {
+  cursor:pointer;
+  color:#eff4ff;
+  font-weight:700;
+}
+
+.decision-faq details p {
+  margin:10px 0 0;
+  color:#c6d3ef;
+  line-height:1.5;
+}
+
 .signal-row {
   margin:22px 0 0;
   padding:0;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,6 +3,7 @@ import { wireOptionalLink } from "./modules/links.js";
 import { initRevealAnimations } from "./modules/reveal.js";
 import { updateYear } from "./modules/year.js";
 import { initHeaderCondense, initHeroParallax, initScrollNavigation } from "./modules/interactions.js";
+import { initConversionTracking } from "./modules/tracking.js";
 
 updateYear();
 wireOptionalLink("appsLink", LINKS.linktreeOrApps);
@@ -11,3 +12,4 @@ initRevealAnimations();
 initHeaderCondense();
 initHeroParallax();
 initScrollNavigation();
+initConversionTracking();

--- a/assets/js/modules/tracking.js
+++ b/assets/js/modules/tracking.js
@@ -1,0 +1,35 @@
+function emitTrack(eventName, payload = {}) {
+  const data = {
+    event: eventName,
+    timestamp: new Date().toISOString(),
+    ...payload
+  };
+
+  if (Array.isArray(window.dataLayer)) {
+    window.dataLayer.push(data);
+  }
+
+  window.dispatchEvent(new CustomEvent("hs-track", { detail: data }));
+}
+
+export function initConversionTracking() {
+  document.querySelectorAll("[data-track]").forEach((el) => {
+    el.addEventListener("click", () => {
+      emitTrack(el.dataset.track, {
+        source: el.dataset.trackSource || "unknown"
+      });
+    });
+  });
+
+  document.querySelectorAll(".decision-faq details[data-faq-question]").forEach((entry) => {
+    entry.addEventListener("toggle", () => {
+      if (!entry.open) {
+        return;
+      }
+
+      emitTrack("faq_expand", {
+        question: entry.dataset.faqQuestion
+      });
+    });
+  });
+}

--- a/index.html
+++ b/index.html
@@ -46,9 +46,29 @@
               Discovery, Umsetzung und Optimierung aus einer Hand.
             </p>
             <div class="cta">
-              <a class="btn primary" href="#contact">Projektgespräch buchen</a>
+              <a class="btn primary" href="#contact" data-track="lead_started" data-track-source="hero-cta">Projektgespräch buchen</a>
               <a class="btn" href="#work">Selected Work ansehen</a>
             </div>
+            <p class="response-time" aria-label="Antwortzeit">Antwort in der Regel innerhalb von <strong>1 Werktag</strong>.</p>
+            <section class="decision-faq" aria-label="Entscheidungshilfe">
+              <p class="decision-faq-title">Entscheidungshilfe in 60 Sekunden</p>
+              <details data-faq-question="fit">
+                <summary>Für welche Teams ist das passend?</summary>
+                <p>Für Teams mit klarem Produktdruck, die kurzfristig seniorige iOS-/Backend-Delivery brauchen und gleichzeitig Architektur stabil halten wollen.</p>
+              </details>
+              <details data-faq-question="timeline">
+                <summary>Wie schnell bekommst du ein erstes Ergebnis?</summary>
+                <p>Innerhalb von 7 Tagen gibt es typischerweise einen sichtbaren Delivery-Schritt: z. B. ein priorisiertes Scope-Paket, ein stabiler Fix oder ein live-fähiges Feature-Inkrement.</p>
+              </details>
+              <details data-faq-question="process">
+                <summary>Wie läuft das 20-Min-Gespräch ab?</summary>
+                <p>Wir klären Zielbild, Engpässe und Priorität. Danach bekommst du eine klare Empfehlung mit nächstem konkretem Schritt statt unverbindlichem „Wir melden uns".</p>
+              </details>
+              <details data-faq-question="start-date">
+                <summary>Wann ist der schnellste Starttermin?</summary>
+                <p>Wenn Scope und Verantwortlichkeiten klar sind, kann der Einstieg oft innerhalb weniger Werktage erfolgen.</p>
+              </details>
+            </section>
             <ul class="signal-row" aria-label="Leistungsversprechen">
               <li><strong>&lt; 7 Tage</strong> bis zum ersten sichtbaren Delivery-Schritt</li>
               <li><strong>Wöchentlich</strong> klarer Scope + Outcome-Update</li>
@@ -234,8 +254,8 @@
             <p class="muted">Am besten starten wir mit einem kurzen Projektgespräch. Danach bekommst du ein klares Vorgehen statt vager Schätzung.</p>
           </div>
           <div class="cta" role="list">
-            <a class="btn primary" href="mailto:hendrik.schneemann@icloud.com" role="listitem">Projektgespräch per E-Mail</a>
-            <a class="btn" href="tel:+491774834706" role="listitem">Kurz telefonieren</a>
+            <a class="btn primary" href="mailto:hendrik.schneemann@icloud.com" role="listitem" data-track="lead_submitted" data-track-source="contact-email">Projektgespräch per E-Mail</a>
+            <a class="btn" href="tel:+491774834706" role="listitem" data-track="lead_submitted" data-track-source="contact-phone">Kurz telefonieren</a>
             <a class="btn" href="#" id="linkedinLink" rel="noopener noreferrer" role="listitem">LinkedIn</a>
           </div>
         </div>

--- a/src/partials/contact.html
+++ b/src/partials/contact.html
@@ -7,8 +7,8 @@
             <p class="muted">Am besten starten wir mit einem kurzen Projektgespräch. Danach bekommst du ein klares Vorgehen statt vager Schätzung.</p>
           </div>
           <div class="cta" role="list">
-            <a class="btn primary" href="mailto:hendrik.schneemann@icloud.com" role="listitem">Projektgespräch per E-Mail</a>
-            <a class="btn" href="tel:+491774834706" role="listitem">Kurz telefonieren</a>
+            <a class="btn primary" href="mailto:hendrik.schneemann@icloud.com" role="listitem" data-track="lead_submitted" data-track-source="contact-email">Projektgespräch per E-Mail</a>
+            <a class="btn" href="tel:+491774834706" role="listitem" data-track="lead_submitted" data-track-source="contact-phone">Kurz telefonieren</a>
             <a class="btn" href="#" id="linkedinLink" rel="noopener noreferrer" role="listitem">LinkedIn</a>
           </div>
         </div>

--- a/src/partials/hero.html
+++ b/src/partials/hero.html
@@ -12,9 +12,29 @@
               Discovery, Umsetzung und Optimierung aus einer Hand.
             </p>
             <div class="cta">
-              <a class="btn primary" href="#contact">Projektgespräch buchen</a>
+              <a class="btn primary" href="#contact" data-track="lead_started" data-track-source="hero-cta">Projektgespräch buchen</a>
               <a class="btn" href="#work">Selected Work ansehen</a>
             </div>
+            <p class="response-time" aria-label="Antwortzeit">Antwort in der Regel innerhalb von <strong>1 Werktag</strong>.</p>
+            <section class="decision-faq" aria-label="Entscheidungshilfe">
+              <p class="decision-faq-title">Entscheidungshilfe in 60 Sekunden</p>
+              <details data-faq-question="fit">
+                <summary>Für welche Teams ist das passend?</summary>
+                <p>Für Teams mit klarem Produktdruck, die kurzfristig seniorige iOS-/Backend-Delivery brauchen und gleichzeitig Architektur stabil halten wollen.</p>
+              </details>
+              <details data-faq-question="timeline">
+                <summary>Wie schnell bekommst du ein erstes Ergebnis?</summary>
+                <p>Innerhalb von 7 Tagen gibt es typischerweise einen sichtbaren Delivery-Schritt: z. B. ein priorisiertes Scope-Paket, ein stabiler Fix oder ein live-fähiges Feature-Inkrement.</p>
+              </details>
+              <details data-faq-question="process">
+                <summary>Wie läuft das 20-Min-Gespräch ab?</summary>
+                <p>Wir klären Zielbild, Engpässe und Priorität. Danach bekommst du eine klare Empfehlung mit nächstem konkretem Schritt statt unverbindlichem „Wir melden uns".</p>
+              </details>
+              <details data-faq-question="start-date">
+                <summary>Wann ist der schnellste Starttermin?</summary>
+                <p>Wenn Scope und Verantwortlichkeiten klar sind, kann der Einstieg oft innerhalb weniger Werktage erfolgen.</p>
+              </details>
+            </section>
             <ul class="signal-row" aria-label="Leistungsversprechen">
               <li><strong>&lt; 7 Tage</strong> bis zum ersten sichtbaren Delivery-Schritt</li>
               <li><strong>Wöchentlich</strong> klarer Scope + Outcome-Update</li>


### PR DESCRIPTION
## Summary

Ergänzt in der Hero-Sektion direkt am primären CTA eine kompakte Entscheidungshilfe (FAQ), reduziert Unsicherheit beim Erstkontakt und macht die erwartete Reaktionszeit explizit.

## Changes

- Added response-time hint next to the primary CTA ("Antwort in der Regel innerhalb von 1 Werktag")
- Added compact Decision-FAQ block with 4 concrete questions (Fit, Timing, Ablauf, Starttermin)
- Added conversion/event tracking module for:
  - `faq_expand` (per opened question)
  - `lead_started` (hero CTA click)
  - `lead_submitted` (email/phone contact action)
- Wired tracking initialization in main JS bundle

## Testing

- Rebuilt `index.html` from template and partials (`./scripts/build-html.sh`)
- Verified tracking attributes and FAQ markup are present in generated HTML

Fixes hsnowmansch/hschneemannWebsite#13